### PR TITLE
Add support for directly connecting Forgeries to OCMock via the podspec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.1 September 15 2015
+
+- Add support for CocoaPods frameworks + semi-weak OCMock linking via the `Mocks` subspec.
+
 ## 0.2.0 August 4 2015
 
 - Adds ForgeriesDefaults.
@@ -5,4 +9,3 @@
 ## 0.1.0 August 3 2015
 
 - Adds gesture recognizer subclasses.
-

--- a/Forgeries.podspec
+++ b/Forgeries.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "Forgeries"
-  s.version          = "0.2.0"
+  s.version          = "0.2.1"
   s.summary          = "Helper methods for testing iOS code."
   s.description      = <<-DESC
                        Some helper methods for writing unit tests against iOS code. Currently:
@@ -9,13 +9,23 @@ Pod::Spec.new do |s|
                        DESC
   s.homepage         = "https://github.com/ashfurrow/Forgeries"
   s.license          = 'MIT'
-  s.authors          = { "Ash Furrow" => "ash@ashfurrow.com", 
+  s.authors          = { "Ash Furrow" => "ash@ashfurrow.com",
                          "Orta Therox" => "orta.therox@gmail.com" }
   s.source           = { :git => "https://github.com/ashfurrow/Forgeries.git", :tag => s.version }
   s.social_media_url = 'https://twitter.com/ashfurrow'
   s.platform     = :ios, '7.0'
   s.requires_arc = true
-  s.source_files = 'Pod/Classes/**/*'
-  s.public_header_files = 'Pod/Classes/**/*.h'
-  s.frameworks = 'UIKit'
+  s.default_subspec = "Core"
+
+  s.subspec "Core" do |ss|
+    ss.source_files = 'Pod/Classes/**/*'
+    ss.public_header_files = 'Pod/Classes/**/*.h'
+  end
+
+  s.subspec "Mocks" do |ss|
+    # Allow CP frameworks to specificly connect the two
+    ss.dependency "OCMock"
+    ss.dependency "Forgeries/Core"
+  end
+
 end

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Circle CI](https://circleci.com/gh/ashfurrow/Forgeries.svg?style=svg)](https://circleci.com/gh/ashfurrow/Forgeries)
 
-Forgeries is a library that makes unit testing iOS applications easier. UIKit has lots of limitations 
+Forgeries is a library that makes unit testing iOS applications easier. UIKit has lots of limitations
 that make sense in production code, but make testing difficult. Forgeries fixes that problem.
 
 ## Usage
@@ -33,9 +33,9 @@ These subclasses keep track of the number of times they've invoked their targets
 
 ### User Defaults
 
-There is also a replacement for `NSUserDefaults` named `ForgeriesUserDefaults`. Use this instead of modifying the `standardUserDefaults` singleton. 
+There is also a replacement for `NSUserDefaults` named `ForgeriesUserDefaults`. Use this instead of modifying the `standardUserDefaults` singleton.
 
-The replacement also includes an optional `replaceStandardUserDefaultsWith:`, which uses OCMock. You need to separately install OCMock in order to use this. 
+The replacement also includes an optional `replaceStandardUserDefaultsWith:`, which uses OCMock. You need to separately install OCMock in order to use this.
 
 Or, you can (and should) do the following...
 
@@ -109,6 +109,8 @@ import Forgeries
 @import Forgeries;
 // or #import <Forgeries/Forgeries.h>
 ```
+
+If you're using CocoaPods frameworks and want to use OCMock, you should use `pod 'forgeries/Mocks'`.
 
 ## Author
 


### PR DESCRIPTION
Bumps it to 0.2.1 too, it's not a breaking change but `/shrug`
