### PR TITLE
Initial work on uiapplication tests

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,7 +1,7 @@
 PODS:
   - Expecta (1.0.5)
-  - Forgeries/Core (0.6.0)
-  - Forgeries/Mocks (0.6.0):
+  - Forgeries/Core (0.6.1)
+  - Forgeries/Mocks (0.6.1):
     - Forgeries/Core
     - OCMock
   - OCMock (3.2.2)
@@ -14,11 +14,11 @@ DEPENDENCIES:
 
 EXTERNAL SOURCES:
   Forgeries:
-    :path: ../
+    :path: "../"
 
 SPEC CHECKSUMS:
   Expecta: e1c022fcd33910b6be89c291d2775b3fe27a89fe
-  Forgeries: f284a9cee2368017c019ce3c31304328bc08e963
+  Forgeries: f5c991dda5977f42d11fa9313fd1e17bc3edbb27
   OCMock: 18c9b7e67d4c2770e95bb77a9cc1ae0c91fe3835
   Specta: ac94d110b865115fe60ff2c6d7281053c6f8e8a2
 

--- a/Example/forgeries.xcworkspace/contents.xcworkspacedata
+++ b/Example/forgeries.xcworkspace/contents.xcworkspacedata
@@ -7,7 +7,4 @@
    <FileRef
       location = "group:Pods/Pods.xcodeproj">
    </FileRef>
-   <FileRef
-      location = "group:forgeries.xcodeproj">
-   </FileRef>
 </Workspace>

--- a/Pod/Classes/ForgeriesApplication.h
+++ b/Pod/Classes/ForgeriesApplication.h
@@ -1,0 +1,9 @@
+#import <UIKit/UIKit.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface ForgeriesApplication : UIApplication
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Pod/Classes/ForgeriesApplication.h
+++ b/Pod/Classes/ForgeriesApplication.h
@@ -3,7 +3,6 @@
 NS_ASSUME_NONNULL_BEGIN
 
 @interface ForgeriesApplication : UIApplication
-
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Pod/Classes/ForgeriesApplication.m
+++ b/Pod/Classes/ForgeriesApplication.m
@@ -11,13 +11,22 @@
 
 @synthesize statusBarHidden=ourStatusBarHidden;
 
-
 /// We can't call the super init function
 /// or it will raise
 
 - (instancetype)init
 {
     return self;
+}
+
+- (BOOL)statusBarHidden
+{
+    return ourStatusBarHidden;
+}
+
+- (BOOL)isStatusBarHidden
+{
+    return ourStatusBarHidden;
 }
 
 - (void)setStatusBarHidden:(BOOL)statusBarHidden

--- a/Pod/Classes/ForgeriesApplication.m
+++ b/Pod/Classes/ForgeriesApplication.m
@@ -1,0 +1,16 @@
+#import "Forgeries-Macros.h"
+#import "ForgeriesApplication.h"
+#import <OCMock/OCMock.h>
+
+
+@implementation ForgeriesApplication
+
+/// We can't call the super init function
+/// or it will raise
+
+- (instancetype)init
+{
+    return self;
+}
+
+@end

--- a/Pod/Classes/ForgeriesApplication.m
+++ b/Pod/Classes/ForgeriesApplication.m
@@ -3,7 +3,14 @@
 #import <OCMock/OCMock.h>
 
 
+@interface ForgeriesApplication()
+@property(nonatomic,getter=isStatusBarHidden) BOOL statusBarHidden;
+@end
+
 @implementation ForgeriesApplication
+
+@synthesize statusBarHidden=ourStatusBarHidden;
+
 
 /// We can't call the super init function
 /// or it will raise
@@ -11,6 +18,16 @@
 - (instancetype)init
 {
     return self;
+}
+
+- (void)setStatusBarHidden:(BOOL)statusBarHidden
+{
+    ourStatusBarHidden = statusBarHidden;
+}
+
+- (void)setStatusBarHidden:(BOOL)hidden withAnimation:(UIStatusBarAnimation)animation
+{
+    self.statusBarHidden = hidden;
 }
 
 @end


### PR DESCRIPTION
The `UIApplication` init function will raise, but the init function is only a convention and not necessary to build the app ( see more context in [our slack](https://artsy.slack.com/archives/mobile/p1455013406001240))

orta [10:24] 
OK @alloy weird question
I want to make a UIApplication subclass
but I can’t call its init, as its init will raise an exception(edited)
could I do
an init for NSObject?
it’s for forgeries for a UIApplication
subclassing means it works with swift code, but I have to somehow not call the super init :confused:

alloy [10:25] 
Technically you could just ​_not_​ call init :simple_smile:
I’m not sure what `-[UIApplication init]` would normally do, but if it’s ​_only_​ raising, then only calling `alloc` should be fine

orta [10:27] 
ah yeah, so alloc gives it the associated memory etc
what’s NSObject’s init job then ( roughly?)(edited)

alloy [10:27] 
To perform class specific setup work
Setup initial ivar values etc
Just the things that you would normally put in an init method

orta [10:28] 
makes sense

alloy [10:29] 
Unlike with Ruby, where `#initialize` is an integral part of the setup procedure, a objc `init` method is really just a convention, it’s nothing special otherwise

orta [10:30] 
cool
so this,

```
- (instancetype)init
{
    return self;
}
```

is a legit init function, cause self alreaddy exists
you’re just letting it chain normally

alloy [10:30] 
And now I recall that even in Ruby you can circumvent `#initialize` from being called:

```
~/C/A/eigen [sale-information-modal] » irb
irb(main):001:0> class X
irb(main):002:1> def initialize
irb(main):003:2> p :ok
irb(main):004:2> end
irb(main):005:1> end
=> :initialize
irb(main):006:0> X.allocate
=> #<X:0x007f9e31a0c310>
irb(main):007:0> X.new
:ok
=> #<X:0x007f9e31a056f0>
```

Aye, totes
With the foot note that historically, you would make sure that self from super is really not nil, etc etc
But in normal cases (possibly all nowadays?), you can just return self, it’ll be fine

orta [10:32] 
I think now that swift has un-failable inits by default it is not really possible without underlying memory corruption

alloy [10:33] 
Maybe, not sure, I’m not that trusting of ‘safety’ :simple_smile:
I’d wonder what would happen when you’re simply out of memory
Which is going to be really hard, ofc :smile:
(with virtual mem etc)
