### PR TITLE
Support using Core without OCMock available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.6.2
+
+- Core runs without OCMock now
+
 ## 0.6.1 February 8 2016
 
 - Removes duplicate category file.
@@ -11,7 +15,7 @@
 
 - NSFileManager shpport.
 
-## 0.2.2 
+## 0.2.2
 
 - Adds removeObjectForKey to ForgeriesDefault
 

--- a/Pod/Classes/ForgeriesFileManager.m
+++ b/Pod/Classes/ForgeriesFileManager.m
@@ -1,6 +1,5 @@
 #import "Forgeries-Macros.h"
 #import "ForgeriesFileManager.h"
-#import <OCMock/OCMock.h>
 
 @implementation ForgeryFile
 

--- a/Pod/Classes/ForgeriesUserDefaults.m
+++ b/Pod/Classes/ForgeriesUserDefaults.m
@@ -1,5 +1,4 @@
 #import "ForgeriesUserDefaults.h"
-#import <OCMock/OCMock.h>
 
 @interface ForgeriesUserDefaults ()
 // This is used by QLPreviewController for something.


### PR DESCRIPTION
Looks like we missed some imports as a part of splitting out the OCMock stuff into it's own subspec
